### PR TITLE
Fixed frontend network error on EC2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,10 @@ services:
     command: sh -c "sleep 10 && python run.py"
 
   frontend:
-    build: ./client
+    build: 
+      context: ./client
+      args:
+        - VITE_API_BASE_URL=http://${APP_HOST}:5001
     ports:
       - "5173:80"
     environment:


### PR DESCRIPTION
Fixed frontend network error by adding VITE_API_BASE_URL arg to docker-compose