### PR TITLE
feat(stock-search): replace manual symbol entry with live stock search

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -4,6 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # index.html must never be cached so browsers always pick up new bundle hashes
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri /index.html;
+    }
+
     # Handle React Router - serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/client/src/components/common/ControlPanel.tsx
+++ b/client/src/components/common/ControlPanel.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import ActionInputBar, { ActionInputBarProps } from "./ActionInputBar";
+import StockSearchInput from "./StockSearchInput";
+
 interface ButtonProps {
     label: string;
     onClick: () => void;
@@ -9,6 +11,7 @@ interface ButtonProps {
 export interface ControlPanelProps {
     buttons?: ButtonProps[];
     actionInputBar?: ActionInputBarProps;
+    onStockSelect?: (symbol: string) => void;
     children: React.ReactNode;
     info?: string;
 }
@@ -26,11 +29,10 @@ const ControlPanel = (props: ControlPanelProps) => {
         <div className="flex flex-col gap-3 w-full">
             <div className="flex flex-col md:flex-row items-center justify-between gap-3 w-full bg-form-bg p-3 rounded-lg shadow-inner border border-border-main/10">
                 <div className="flex-1 w-full md:max-w-[400px]">
-                {props.actionInputBar && (
-                    <ActionInputBar
-                        {...props.actionInputBar}
-                    />
-                )}
+                {props.onStockSelect
+                    ? <StockSearchInput onStockSelect={props.onStockSelect} />
+                    : props.actionInputBar && <ActionInputBar {...props.actionInputBar} />
+                }
                 </div>
                 {props.buttons && (
                     <div className="flex items-center gap-3 flex-wrap justify-center">

--- a/client/src/components/common/StockSearchInput.tsx
+++ b/client/src/components/common/StockSearchInput.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from "react";
+import { authGet } from "../../utils/api";
+import { DATA_ENDPOINTS } from "../../constants/api";
+
+interface SearchResult {
+    symbol: string;
+    name: string;
+    type: string;
+    exchange: string;
+}
+
+interface StockSearchInputProps {
+    onStockSelect: (symbol: string) => void;
+    disabled?: boolean;
+}
+
+const StockSearchInput = ({ onStockSelect, disabled }: StockSearchInputProps) => {
+    const [query, setQuery] = useState("");
+    const [results, setResults] = useState<SearchResult[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+
+    // 1. useEffect that watches `query` — after 300ms calls the API
+    //    hint: use a cleanup function to cancel the timeout if query changes
+    // 2. handler for when user clicks a result
+    //    → call onStockSelect(result.symbol), clear query, clear results
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            if (query.length < 2) {
+                setResults([]);
+                return;
+            }
+            setLoading(true);
+            authGet(`${DATA_ENDPOINTS.SEARCH}?q=${query}`)
+                .then(data => setResults(data as SearchResult[]))
+                .catch(error => console.error("Error searching for stocks:", error))
+                .finally(() => setLoading(false));
+        }, 300);
+        return () => clearTimeout(timeout);
+    }, [query]);
+    return (
+        <div className="relative bg-input-bg border border-border-main/40 rounded-lg px-2 py-0.5 my-0.5 flex items-center shadow-inner transition-all hover:border-primary/50 focus-within:ring-2 focus-within:ring-primary/50 focus-within:border-primary">
+            <input 
+                className="mr-0 h-8 border-none bg-transparent outline-none flex-1 text-sm text-text-main placeholder-text-main/50 px-2"
+                type="text" 
+                placeholder="Search for a stock"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                disabled={disabled}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+            />  
+            {(loading || results.length > 0) && (
+                <div className="absolute top-full left-0 w-full bg-list-bg border border-border-main rounded-lg shadow-lg max-h-48 overflow-y-auto z-50">
+                    {loading ? (
+                        <div className="px-4 py-2 text-sm text-text-main/50">Loading...</div>
+                    ) : (
+                        results.map(result => (
+                            <div
+                                key={result.symbol}
+                                className="px-4 py-2 text-sm text-text-main hover:bg-row-hover flex items-center justify-between gap-2"
+                            >
+                                <span className="truncate">{result.name}</span>
+                                <div className="flex items-center gap-2 shrink-0">
+                                    <span className="text-text-main/50 font-mono text-xs">{result.symbol}</span>
+                                    <button
+                                        onMouseDown={(e) => { e.preventDefault(); onStockSelect(result.symbol); setQuery(""); setResults([]); }}
+                                        className="w-5 h-5 rounded-full border-2 border-primary hover:bg-primary/10 active:scale-90 flex items-center justify-center transition-all"
+                                        title={`Add ${result.symbol}`}
+                                    >
+                                        <svg className="w-2.5 h-2.5 text-primary" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        ))
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default StockSearchInput;

--- a/client/src/components/common/StockTable.tsx
+++ b/client/src/components/common/StockTable.tsx
@@ -389,12 +389,7 @@ const StockTable: React.FC<StockTableProps> = ({
 
     return (
         <ControlPanel
-            actionInputBar={{
-                onClick: (symbol: string) => { void onAdd(symbol); },
-                disabled: false,
-                placeholder: "Symbol i.e. NVDA",
-                buttonLabel: "Add"
-            }}
+            onStockSelect={(symbol: string) => { void onAdd(symbol); }}
             buttons={[{
                 label: "Refresh",
                 onClick: () => { void onRefresh(); },

--- a/client/src/components/common/__tests__/StockSearchInput.test.tsx
+++ b/client/src/components/common/__tests__/StockSearchInput.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import StockSearchInput from '../StockSearchInput';
+
+const mockAuthGet = vi.fn();
+
+vi.mock('../../../utils/api', () => ({
+    authGet: (...args: unknown[]) => mockAuthGet(...args),
+}));
+
+vi.mock('../../../constants/api', () => ({
+    DATA_ENDPOINTS: { SEARCH: 'http://localhost/data/search' },
+}));
+
+const MOCK_RESULTS = [
+    { symbol: 'AAPL', name: 'Apple Inc',  type: 'Equity', exchange: 'United States' },
+    { symbol: 'TSLA', name: 'Tesla Inc',  type: 'Equity', exchange: 'United States' },
+];
+
+describe('StockSearchInput', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockAuthGet.mockResolvedValue(MOCK_RESULTS);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it('renders the search input with correct placeholder', () => {
+        render(<StockSearchInput onStockSelect={vi.fn()} />);
+        expect(screen.getByPlaceholderText('Search for a stock')).toBeInTheDocument();
+    });
+
+    it('does not call the API when query is shorter than 2 characters', async () => {
+        render(<StockSearchInput onStockSelect={vi.fn()} />);
+        fireEvent.change(screen.getByPlaceholderText('Search for a stock'), { target: { value: 'a' } });
+        await act(async () => { vi.advanceTimersByTime(400); });
+        expect(mockAuthGet).not.toHaveBeenCalled();
+    });
+
+    it('calls authGet with the search query after the 300ms debounce', async () => {
+        render(<StockSearchInput onStockSelect={vi.fn()} />);
+        fireEvent.change(screen.getByPlaceholderText('Search for a stock'), { target: { value: 'ap' } });
+        await act(async () => { vi.advanceTimersByTime(300); });
+        expect(mockAuthGet).toHaveBeenCalledWith('http://localhost/data/search?q=ap');
+    });
+
+    it('does not fire early if typing before debounce expires', async () => {
+        render(<StockSearchInput onStockSelect={vi.fn()} />);
+        const input = screen.getByPlaceholderText('Search for a stock');
+        fireEvent.change(input, { target: { value: 'ap' } });
+        await act(async () => { vi.advanceTimersByTime(100); });
+        fireEvent.change(input, { target: { value: 'app' } });
+        await act(async () => { vi.advanceTimersByTime(100); });
+        // Only 200ms total elapsed since last keypress — should not have fired yet
+        expect(mockAuthGet).not.toHaveBeenCalled();
+    });
+
+    it('shows results in the dropdown after API responds', async () => {
+        render(<StockSearchInput onStockSelect={vi.fn()} />);
+        fireEvent.change(screen.getByPlaceholderText('Search for a stock'), { target: { value: 'ap' } });
+        await act(async () => { vi.advanceTimersByTime(300); });
+        await waitFor(() => {
+            expect(screen.getByText('Apple Inc')).toBeInTheDocument();
+            expect(screen.getByText('AAPL')).toBeInTheDocument();
+            expect(screen.getByText('Tesla Inc')).toBeInTheDocument();
+        });
+    });
+
+    it('clicking the + button calls onStockSelect with the correct symbol', async () => {
+        const onStockSelect = vi.fn();
+        render(<StockSearchInput onStockSelect={onStockSelect} />);
+        fireEvent.change(screen.getByPlaceholderText('Search for a stock'), { target: { value: 'ap' } });
+        await act(async () => { vi.advanceTimersByTime(300); });
+        await waitFor(() => screen.getByTitle('Add AAPL'));
+
+        fireEvent.mouseDown(screen.getByTitle('Add AAPL'));
+        expect(onStockSelect).toHaveBeenCalledWith('AAPL');
+    });
+
+    it('clears the query and results after a stock is selected', async () => {
+        render(<StockSearchInput onStockSelect={vi.fn()} />);
+        const input = screen.getByPlaceholderText('Search for a stock');
+        fireEvent.change(input, { target: { value: 'ap' } });
+        await act(async () => { vi.advanceTimersByTime(300); });
+        await waitFor(() => screen.getByTitle('Add AAPL'));
+
+        fireEvent.mouseDown(screen.getByTitle('Add AAPL'));
+        expect(input).toHaveValue('');
+        await waitFor(() => expect(screen.queryByText('Apple Inc')).not.toBeInTheDocument());
+    });
+});

--- a/client/src/constants/api.ts
+++ b/client/src/constants/api.ts
@@ -25,6 +25,7 @@ export const DATA_ENDPOINTS = {
     NEWS: `${API_BASE_URL}/data/news`,
     IN_DEPTH: `${API_BASE_URL}/data/in_depth_data`,
     CHART: `${API_BASE_URL}/data/chart_data`,
+    SEARCH: `${API_BASE_URL}/data/search`,
 } as const;
 
 // AlphaBot endpoints

--- a/server/app/routes/stock_data.py
+++ b/server/app/routes/stock_data.py
@@ -1,3 +1,6 @@
+import os
+import dataclasses
+from app.services.search_provider import AlphaVantageStockSearchProvider
 import datetime
 from flask import jsonify, Blueprint, request, current_app
 from app import db, cache
@@ -163,3 +166,12 @@ def chart_data():
     except Exception as e:
         current_app.logger.error(f"Error fetching chart data: {str(e)}")
         return jsonify({"error": str(e)}), 500
+@bp.route('/search', methods=['GET'])
+@login_required
+def search():
+    q = request.args.get('q', '').strip()
+    if not q:
+        return jsonify({'error': 'q is required'}), 400
+    provider = AlphaVantageStockSearchProvider(api_key=os.getenv('ALPHA_VANTAGE_KEY'))
+    results = provider.search(q)
+    return jsonify([dataclasses.asdict(result) for result in results]), 200

--- a/server/app/services/search_provider.py
+++ b/server/app/services/search_provider.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from typing import List
+import requests
+import os
+"""
+SearchResult is a dataclass that represents a search result.
+It has the following fields:
+- symbol: str
+- name: str
+- type: str
+- exchange: str
+"""
+@dataclass
+class SearchResult:
+    symbol: str
+    name: str
+    type: str
+    exchange: str
+
+"""
+StockSearchProvider is an abstract base class for stock search providers.
+It defines the interface for stock search providers and is used to search for stocks.
+""" 
+class StockSearchProvider(ABC):
+    @abstractmethod
+    def search(self, query: str) -> List[SearchResult]:
+        pass
+
+"""
+AlphaVantageStockSearchProvider is a concrete implementation of StockSearchProvider that uses the Alpha Vantage API to search for stocks.
+It implements the search method to search for stocks based on a query.
+"""
+class AlphaVantageStockSearchProvider(StockSearchProvider):
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    def search(self, query: str) -> List[SearchResult]:
+        url = "https://www.alphavantage.co/query"
+        response = requests.get(url, params={
+            "function": "SYMBOL_SEARCH", 
+            "keywords": query, 
+            "apikey": self._api_key
+        })
+        if response.status_code != 200:
+            raise Exception(f"Failed to search for {query}: {response.status_code} {response.text}")
+
+        data = response.json()
+        return [SearchResult(
+            symbol=result["1. symbol"], 
+            name=result["2. name"], 
+            type=result["3. type"], 
+            exchange=result["4. region"]
+            ) 
+            for result in data.get("bestMatches", [])
+            if result.get("4. region") == "United States"
+        ]
+

--- a/server/tests/test_stock_data.py
+++ b/server/tests/test_stock_data.py
@@ -1,12 +1,13 @@
 """
 test_stock_data.py — integration tests for the /data/* routes.
 
-All four routes (/news, /stock_data, /in_depth_data, /chart_data)
+All four routes (/news, /stock_data, /in_depth_data, /chart_data, /search)
 are behind @login_required. We test auth guards, missing payloads,
 and mock the external Alpha Vantage API so tests run offline.
 """
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from app.services.search_provider import AlphaVantageStockSearchProvider, SearchResult
 
 
 class TestStockDataAuth:
@@ -115,3 +116,102 @@ class TestChartData:
         assert len(data) == 2
         assert "time" in data[0]
         assert "value" in data[0]
+
+
+# ---------------------------------------------------------------------------
+# Stock Search — provider unit tests
+# ---------------------------------------------------------------------------
+
+AV_RESPONSE = {
+    "bestMatches": [
+        {"1. symbol": "AAPL",      "2. name": "Apple Inc",     "3. type": "Equity", "4. region": "United States"},
+        {"1. symbol": "AAPL.LON",  "2. name": "Apple Inc",     "3. type": "Equity", "4. region": "London"},
+        {"1. symbol": "TSLA",      "2. name": "Tesla Inc",     "3. type": "Equity", "4. region": "United States"},
+        {"1. symbol": "TSLA34.SAO","2. name": "Tesla Inc",     "3. type": "Equity", "4. region": "Brazil/Sao Paolo"},
+    ]
+}
+
+
+class TestAlphaVantageStockSearchProvider:
+    """Unit tests for AlphaVantageStockSearchProvider — no network calls."""
+
+    def _make_mock_response(self, json_data, status_code=200):
+        mock = MagicMock()
+        mock.status_code = status_code
+        mock.json.return_value = json_data
+        mock.text = str(json_data)
+        return mock
+
+    def test_returns_only_us_results(self):
+        provider = AlphaVantageStockSearchProvider(api_key="fake")
+        with patch("app.services.search_provider.requests.get",
+                   return_value=self._make_mock_response(AV_RESPONSE)):
+            results = provider.search("apple")
+        symbols = [r.symbol for r in results]
+        assert "AAPL" in symbols
+        assert "TSLA" in symbols
+        assert "AAPL.LON" not in symbols
+        assert "TSLA34.SAO" not in symbols
+
+    def test_returns_search_result_dataclasses(self):
+        provider = AlphaVantageStockSearchProvider(api_key="fake")
+        with patch("app.services.search_provider.requests.get",
+                   return_value=self._make_mock_response(AV_RESPONSE)):
+            results = provider.search("apple")
+        assert all(isinstance(r, SearchResult) for r in results)
+        aapl = next(r for r in results if r.symbol == "AAPL")
+        assert aapl.name == "Apple Inc"
+        assert aapl.exchange == "United States"
+
+    def test_empty_best_matches_returns_empty_list(self):
+        provider = AlphaVantageStockSearchProvider(api_key="fake")
+        with patch("app.services.search_provider.requests.get",
+                   return_value=self._make_mock_response({"bestMatches": []})):
+            results = provider.search("zzzzz")
+        assert results == []
+
+    def test_non_200_response_raises_exception(self):
+        provider = AlphaVantageStockSearchProvider(api_key="fake")
+        with patch("app.services.search_provider.requests.get",
+                   return_value=self._make_mock_response({}, status_code=500)):
+            with pytest.raises(Exception, match="500"):
+                provider.search("apple")
+
+
+# ---------------------------------------------------------------------------
+# Stock Search — GET /data/search route tests
+# ---------------------------------------------------------------------------
+
+class TestSearchRoute:
+    """Integration tests for GET /data/search."""
+
+    def test_requires_auth(self, client):
+        resp = client.get("/data/search?q=apple")
+        assert resp.status_code == 401
+
+    def test_missing_query_param_returns_400(self, client, auth_headers):
+        resp = client.get("/data/search", headers=auth_headers)
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_valid_query_returns_us_results(self, client, auth_headers):
+        mock_results = [
+            SearchResult(symbol="AAPL", name="Apple Inc", type="Equity", exchange="United States"),
+        ]
+        with patch("app.routes.stock_data.AlphaVantageStockSearchProvider") as MockProvider:
+            MockProvider.return_value.search.return_value = mock_results
+            resp = client.get("/data/search?q=apple", headers=auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert data[0]["symbol"] == "AAPL"
+        assert data[0]["name"] == "Apple Inc"
+
+    def test_no_matches_returns_empty_list(self, client, auth_headers):
+        with patch("app.routes.stock_data.AlphaVantageStockSearchProvider") as MockProvider:
+            MockProvider.return_value.search.return_value = []
+            resp = client.get("/data/search?q=zzzzz", headers=auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.get_json() == []


### PR DESCRIPTION
- Add AlphaVantageStockSearchProvider using adapter pattern (search_provider.py)
- Add GET /data/search endpoint with login_required guard
- Filter results to US exchanges only to remove duplicate foreign listings
- Add StockSearchInput component with 300ms debounce and dropdown results
- Replace ActionInputBar in StockTable with StockSearchInput via ControlPanel
- Add green circular + button on each result row to add stock to watchlist
- Fix nginx.conf to set no-cache on index.html preventing stale bundle loads
- Add unit tests: AlphaVantageStockSearchProvider, /data/search route, StockSearchInput component (15 tests, all passing)